### PR TITLE
Exclude binstubs from being checked with Rubocop

### DIFF
--- a/style/.rubocop.yml
+++ b/style/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
   - "vendor/**/*"
   - "db/**/*"
+  - "bin/**/*"
   DisplayCopNames: false
   StyleGuideCopsOnly: false
 Rails:


### PR DESCRIPTION
Binstubs are most often autogenerated with Bundler or Spring, and never changed.  There is no good reason to lint them.