### PR TITLE
Check style for custom gemfiles

### DIFF
--- a/style/.rubocop.yml
+++ b/style/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Include:
   - "**/*.rake"
   - "**/Gemfile"
+  - "**/*.gemfile"
   - "**/Rakefile"
   Exclude:
   - "vendor/**/*"


### PR DESCRIPTION
Many open source gems define several gemfiles for CI tests against different dependency combinations.  For example, Ribose's [attr_masker](https://github.com/riboseinc/attr_masker/tree/master/gemfiles). These files should be checked as well.