### PR TITLE
Exclude temporary files from Rubocop checks

### DIFF
--- a/style/.rubocop.yml
+++ b/style/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
   - "vendor/**/*"
   - "db/**/*"
+  - "tmp/**/*"
   DisplayCopNames: false
   StyleGuideCopsOnly: false
 Rails:


### PR DESCRIPTION
It's a rare case, but some Ruby scripts may appear in /tmp.  Typically they are autogenerated by some gems, for example Aruba may create pretty arbitrary files for test purposes.  They are volatile, and definitely do not belong to repository.  Checking them in CI seems pointless, and they may be a source of noise when running Rubocop locally.