### PR TITLE
Upgrade linked Thoughtbot's guide (fix warning)

### DIFF
--- a/style/.rubocop.ribose.yml
+++ b/style/.rubocop.ribose.yml
@@ -1,5 +1,5 @@
 inherit_from:
-  - https://raw.githubusercontent.com/thoughtbot/guides/91509c26b3f84beebb239592561e41a77fdd0fa6/style/ruby/.rubocop.yml
+  - https://raw.githubusercontent.com/thoughtbot/guides/9efc3f2e668d40682b33ee9d8c67a4c5d44652f0/style/ruby/.rubocop.yml
 AllCops:
   Include:
   - "**/*.rake"


### PR DESCRIPTION
A tiny update to Thoughtbot's style guide (cop name update), see: https://github.com/thoughtbot/guides/pull/506