### PR TITLE
force include of Ruby files; addresses #12

### DIFF
--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
   - "**/Gemfile"
   - "**/*.gemfile"
   - "**/Rakefile"
+  - "**/*.rb"
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.4


### PR DESCRIPTION
As said in the ticket, no idea when and if Rubocop will fix its omission of actual Ruby files from testing, and you should not be assuming people are restricted to old versions of Rubocop.