### PR TITLE
Remove our Rubocop includes

### DIFF
--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -4,11 +4,6 @@ AllCops:
   - vendor/**/*
   - db/**/*
   - tmp/**/*
-  Include:
-  - "**/*.rake"
-  - "**/Gemfile"
-  - "**/*.gemfile"
-  - "**/Rakefile"
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.4

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -1,9 +1,4 @@
 AllCops:
-  Include:
-  - "**/*.rake"
-  - "**/Gemfile"
-  - "**/*.gemfile"
-  - "**/Rakefile"
   Exclude:
   - "vendor/**/*"
   - "db/**/*"


### PR DESCRIPTION
Rely on Rubocop's defaults, which are far more comprehensive, as of Rubocop v0.54 currently run by Hound CI.

See: https://github.com/rubocop-hq/rubocop/blob/v0.54.0/config/default.yml

Fixes #12. Obsoletes #18.