### PR TITLE
Freeze Rubocop in Hound CI at version 0.54.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,4 @@
 ruby:
   Enabled: true
   config_file: ci/rubocop.yml
+  version: 0.54.0

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
 ruby:
- Enabled: true
- config_file: ci/rubocop.yml
+  Enabled: true
+  config_file: ci/rubocop.yml


### PR DESCRIPTION
As you all know, we use Hound CI to validate our commits against the style guide contained in this repository. Unfortunately, our previous experience is that Rubocop version bumps may cause headaches if they introduce breaking changes—and they frequently do.

Recently, Hound CI added a new feature: we may now enforce specific Rubocop version. This pull request enforces version 0.54.0, which is a default one at the moment I am writing this message.

This pull request should break nothing, however will prevent us from problems in future. I suppose everyone will agree on merging this one, nevertheless I am open for discussion.

cc @opoudjis @ronaldtse @ribose-jeffreylau 

Also, we should discuss upgrading Rubocop to 0.59.2, but that's a separate concern. I'll create a proper pull request for that as soon as we merge in current one.