### PR TITLE
Switch to Rubocop 0.75.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 ruby:
   Enabled: true
   config_file: ci/rubocop.yml
-  version: 0.54.0
+  version: 0.75.0

--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.4
+require:
+- rubocop-rails
+- rubocop-performance
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
@@ -126,7 +129,7 @@ Style/FrozenStringLiteralComment:
   Description: Add the frozen_string_literal comment to the top of files to help transition
     from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: Checks for flip flops
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
   Enabled: false
@@ -255,6 +258,10 @@ Style/RaiseArgs:
 Style/RegexpLiteral:
   Description: Use / or %r around regular expressions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-r
+  Enabled: false
+Style/Sample:
+  Description: Use `sample` instead of `shuffle.first`, `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
   Enabled: false
 Style/SelfAssignment:
   Description: Checks for places where self-assignment shorthand should have been
@@ -451,10 +458,6 @@ Performance/FlatMap:
 Performance/ReverseEach:
   Description: Use `reverse_each` instead of `reverse.each`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code
-  Enabled: false
-Performance/Sample:
-  Description: Use `sample` instead of `shuffle.first`, `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
   Enabled: false
 Performance/Size:
   Description: Use `size` instead of `count` for counting the number of elements in

--- a/src/rubocop/rubocop.tb.yml
+++ b/src/rubocop/rubocop.tb.yml
@@ -2,6 +2,10 @@ AllCops:
   Exclude:
     - db/schema.rb
 
+require:
+  - rubocop-rails
+  - rubocop-performance
+
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
@@ -152,7 +156,7 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: 'Checks for flip flops'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: false
@@ -307,6 +311,13 @@ Style/RaiseArgs:
 Style/RegexpLiteral:
   Description: 'Use / or %r around regular expressions.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
+  Enabled: false
+
+Style/Sample:
+  Description: >-
+    Use `sample` instead of `shuffle.first`,
+    `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: false
 
 Style/SelfAssignment:
@@ -577,13 +588,6 @@ Performance/FlatMap:
 Performance/ReverseEach:
   Description: 'Use `reverse_each` instead of `reverse.each`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
-  Enabled: false
-
-Performance/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: false
 
 Performance/Size:


### PR DESCRIPTION
- Bump Rubocop version to 0.75.0 in Hound CI config
- Upgrade embedded Thoughtbot's guide
- Rebuild style guide from sources

Last time we bumped Rubocop version was exactly one year ago, and it's time to do it again.  Rubocop 0.75.0 is currently the most recent version supported by Hound CI.

Thoughtbot's style guide comes from revision: https://github.com/thoughtbot/guides/blob/a5f5fd36dc/style/ruby/.rubocop.yml. Newer commits address changes which has been introduced to Rubocop after version 0.75, and are not backwards compatible.