### PR TITLE
Feature/update rubocop 1.5.0

### DIFF
--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -170,9 +170,9 @@ Style/LineEndConcatenation:
     end.
   Enabled: false
 Metrics/LineLength:
-  Description: Limit lines to 80 characters.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
-  Max: 80
+  Description: Limit lines to 120 characters.
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#max-line-length
+  Max: 120
   Enabled: true
   AllowURI: true
   URISchemes:

--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -170,9 +170,9 @@ Style/LineEndConcatenation:
     end.
   Enabled: false
 Layout/LineLength:
-  Description: Limit lines to 120 characters.
+  Description: Limit lines to 80 characters.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#max-line-length
-  Max: 120
+  Max: 80
   Enabled: true
   AllowURI: true
   URISchemes:

--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -86,7 +86,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: true
   Max: 25
-  ExcludedMethods: []
+  IgnoredMethods: []
   Exclude:
   - spec/**/*
 Metrics/CyclomaticComplexity:
@@ -169,7 +169,7 @@ Style/LineEndConcatenation:
   Description: Use \ instead of + or << to concatenate two string literals at line
     end.
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Description: Limit lines to 120 characters.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#max-line-length
   Max: 120


### PR DESCRIPTION
https://github.com/rubocop/rubocop/releases/tag/v1.5.0
 - rubocop/rubocop#9098: Update Metrics/BlockLength and Metrics/MethodLength to use IgnoredMethods instead of ExcludedMethods in configuration. The previous key is retained for backwards compatibility.

https://github.com/rubocop/rubocop/releases/tag/v0.78.0
 - rubocop/rubocop#7542: (Breaking) Move LineLength cop from Metrics department to Layout department.

@CAMOBAP don't forget to merge https://github.com/CAMOBAP/oss-guides/pull/1 once this one will be approved