### PR TITLE
Switch to Rubocop 1.5.2 in Hound CI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,4 @@
 ruby:
   Enabled: true
   config_file: ci/rubocop.yml
-  version: 0.75.0
+  version: 1.5.2


### PR DESCRIPTION
The style book has been updated to be compatible with Rubocop 1.5.2 (#31), but Hound CI configuration hasn't been changed accordingly.