### PR TITLE
Preserve recent style book changes for being overwritten

### DIFF
--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -8,6 +8,15 @@ AllCops:
   TargetRubyVersion: 2.4
 Rails:
   Enabled: true
+Layout/LineLength:
+  Description: Limit lines to 80 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
+  Enabled: true
+  Max: 80
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
 Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
@@ -31,15 +40,6 @@ Metrics/CyclomaticComplexity:
     cases needed to validate a method.
   Enabled: true
   Max: 6
-Layout/LineLength:
-  Description: Limit lines to 80 characters.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
-  Enabled: true
-  Max: 80
-  AllowURI: true
-  URISchemes:
-  - http
-  - https
 Metrics/MethodLength:
   Description: Avoid methods longer than 10 lines of code.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -31,7 +31,7 @@ Metrics/CyclomaticComplexity:
     cases needed to validate a method.
   Enabled: true
   Max: 6
-Metrics/LineLength:
+Layout/LineLength:
   Description: Limit lines to 80 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits
   Enabled: true
@@ -59,3 +59,11 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: true
   Max: 7
+
+# From 322cb2c179a721fed382a691124185a01811cf11
+Layout/DotPosition:
+  EnforcedStyle: leading
+
+# From 469568118711e296909e267f6420f67c0747f83d
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma


### PR DESCRIPTION
There were some recent changes made in the compiled style book (`ci/*`) rather than in source files (`src/*`).  In this pull request they are moved to a proper place. Otherwise they would be overwritten at next recompile.