### PR TITLE
Disable all cops from Rails department

### DIFF
--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -6,8 +6,10 @@ AllCops:
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.4
+# These checks are irrelevant for most of our projects as they do not use Rails.
+# They should be re-enabled on project level if applicable.
 Rails:
-  Enabled: true
+  Enabled: false
 Layout/LineLength:
   Description: Limit lines to 80 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits


### PR DESCRIPTION
These checks are completely irrelevant for most of our projects as they do not use Rails.