### PR TITLE
Test style book integrity in GHA

### DIFF
--- a/.github/workflows/integrity_test.yml
+++ b/.github/workflows/integrity_test.yml
@@ -1,0 +1,37 @@
+name: Test integrity
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  rubocop_integrity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: github.repository == 'riboseinc/oss-guides'
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+
+      - name: Install gems
+        run: gem install activesupport
+
+      - name: Recompile the style book
+        run: rake build:rubocop
+
+      - name: Ensure no differences
+        run: |
+          if [ ! -z "$(git status --short)" ]; then
+            echo "--------------------------------------"
+            echo "     Style book is not recompiled     "
+            echo "  ('rake build:rubocop' was not run)  "
+            echo "  or compiled files have been edited  "
+            echo "        instead of source ones        "
+            echo "--------------------------------------"
+          fi


### PR DESCRIPTION
Use GitHub Actions to ensure that no one forgot about recompiling the style book. Should prevent from issues like #44/#45 in future.