### PR TITLE
Update underlying Thoughtbot's style guide

### DIFF
--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -93,7 +93,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: true
   Max: 25
-  ExcludedMethods: []
+  IgnoredMethods: []
   Exclude:
   - spec/**/*
 Metrics/CyclomaticComplexity:

--- a/src/rubocop/rubocop.tb.yml
+++ b/src/rubocop/rubocop.tb.yml
@@ -97,7 +97,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   CountComments: true  # count full line comments?
   Max: 25
-  ExcludedMethods: []
+  IgnoredMethods: []
   Exclude:
     - "spec/**/*"
 


### PR DESCRIPTION
Thoughtbot's style guide comes from revision: https://github.com/thoughtbot/guides/blob/b065c86726e61ac05b96dcc7b4ce7f7e854d406a/ruby/.rubocop.yml

Only tiny changes were made.