### PR TITLE
Small changes to Ruby style book

### DIFF
--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -70,7 +70,7 @@ Style/ClassVars:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-class-vars
   Enabled: false
 Style/CollectionMethods:
-  Enabled: true
+  Enabled: false
   PreferredMethods:
     find: detect
     inject: reduce
@@ -290,7 +290,7 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in argument lists.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
-  EnforcedStyleForMultiline: no_comma
+  EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
   - comma
   - consistent_comma
@@ -516,3 +516,5 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: true
   Max: 7
+Style/ArgumentsForwarding:
+  Enabled: true

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -63,11 +63,9 @@ Metrics/PerceivedComplexity:
   Max: 7
 Style/CollectionMethods:
   Enabled: false
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
 
 # From 322cb2c179a721fed382a691124185a01811cf11
 Layout/DotPosition:
   EnforcedStyle: leading
-
-# From 469568118711e296909e267f6420f67c0747f83d
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: no_comma

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -69,3 +69,8 @@ Style/TrailingCommaInArguments:
 # From 322cb2c179a721fed382a691124185a01811cf11
 Layout/DotPosition:
   EnforcedStyle: leading
+
+# Delete following lines after migrating to Rubocop 2.x, as these checks
+# will be enabled by default.
+Style/ArgumentsForwarding:
+  Enabled: true

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -61,6 +61,8 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: true
   Max: 7
+Style/CollectionMethods:
+  Enabled: false
 
 # From 322cb2c179a721fed382a691124185a01811cf11
 Layout/DotPosition:


### PR DESCRIPTION
About two weeks ago I've opened discussion about following changes:

- Disable Style/CollectionMethods (fixes #35)
- Enable Style/ArgumentsForwarding (fixes #41)
- Reconfigure Style/TrailingCommaInArguments to enforce trailing commas in multiline argument lists (fixes #37)

These changes are non-controversial I think, and I'm going to merge them in a few days unless someone opposes.