### PR TITLE
Bump TargetRubyVersion in rubocop configs to 2.5 (#54)

### DIFF
--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
   - tmp/**/*
   DisplayCopNames: false
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
   NewCops: enable
 require:
 - rubocop-performance

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -5,7 +5,7 @@ AllCops:
   - "tmp/**/*"
   DisplayCopNames: false
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
 Layout/LineLength:
   Description: Limit lines to 80 characters.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#80-character-limits


### PR DESCRIPTION
closes #54