### PR TITLE
rubocop: Enable Style/CollectionCompact for consistent nil checks

### DIFF
--- a/ci/rubocop.rails.yml
+++ b/ci/rubocop.rails.yml
@@ -497,6 +497,11 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: true
   Max: 7
+Style/CollectionCompact:
+  Description: Checks for places where custom logic on rejection nils from arrays
+    and hashes can be replaced with {Array,Hash}#{compact,compact!}.
+  StyleGuide: https://docs.rubocop.org/rubocop/cops_style.html#stylecollectioncompact
+  Enabled: true
 Style/ArgumentsForwarding:
   Enabled: true
 Gemspec/RequireMFA:

--- a/ci/rubocop.yml
+++ b/ci/rubocop.yml
@@ -494,6 +494,11 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: true
   Max: 7
+Style/CollectionCompact:
+  Description: Checks for places where custom logic on rejection nils from arrays
+    and hashes can be replaced with {Array,Hash}#{compact,compact!}.
+  StyleGuide: https://docs.rubocop.org/rubocop/cops_style.html#stylecollectioncompact
+  Enabled: true
 Style/ArgumentsForwarding:
   Enabled: true
 Gemspec/RequireMFA:

--- a/src/rubocop/rubocop.ribose.yml
+++ b/src/rubocop/rubocop.ribose.yml
@@ -61,6 +61,12 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: true
   Max: 7
+
+Style/CollectionCompact:
+  Description: Checks for places where custom logic on rejection nils from arrays and hashes can be replaced with {Array,Hash}#{compact,compact!}.
+  StyleGuide: https://docs.rubocop.org/rubocop/cops_style.html#stylecollectioncompact
+  Enabled: true
+
 Style/CollectionMethods:
   Enabled: false
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
Fixes #49 